### PR TITLE
fix(CMake): make build Qt6 specific

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 
-# Find Qt (Qt6 preferred, fallback to Qt5) with required components.
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets LinguistTools)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets LinguistTools)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS OpenGLWidgets)
+# Find Qt6
+find_package(Qt6 REQUIRED
+    COMPONENTS
+        OpenGLWidgets
+        LinguistTools
+)
 
 # Translation files.
 set(TS_FILES ${CMAKE_SOURCE_DIR}/translations/drawy_en_GB.ts)
@@ -33,39 +35,29 @@ file(GLOB_RECURSE SRC_FILES
 # Combine translation files with the source files.
 set(PROJECT_SOURCES ${TS_FILES} ${SRC_FILES})
 
-if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
-    qt_add_executable(${PROJECT_NAME}
-        MANUAL_FINALIZATION
-        ${PROJECT_SOURCES}
-    )
-    qt_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
-else()
-    if(ANDROID)
-        add_library(${PROJECT_NAME} SHARED
-            ${PROJECT_SOURCES}
-        )
-    else()
-        add_executable(${PROJECT_NAME}
-            ${PROJECT_SOURCES}
-        )
-    endif()
-    qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
-endif()
+qt_add_executable(${PROJECT_NAME}
+    MANUAL_FINALIZATION
+    ${PROJECT_SOURCES}
+)
+qt_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
 
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt${QT_VERSION_MAJOR}::OpenGLWidgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::OpenGLWidgets)
 
 # Set bundle properties for macOS / iOS.
-if(${QT_VERSION} VERSION_LESS 6.1.0)
-  set(BUNDLE_ID_OPTION MACOSX_BUNDLE_GUI_IDENTIFIER com.example.${PROJECT_NAME})
+if (APPLE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        MACOSX_BUNDLE_GUI_IDENTIFIER com.example.${PROJECT_NAME}
+        MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+        MACOSX_BUNDLE TRUE
+    )
 endif()
-set_target_properties(${PROJECT_NAME} PROPERTIES
-    ${BUNDLE_ID_OPTION}
-    MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
-    MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
-    MACOSX_BUNDLE TRUE
-    WIN32_EXECUTABLE TRUE
-)
+
+if (WIN32)
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        WIN32_EXECUTABLE TRUE
+    )
+endif()
 
 include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}
@@ -75,6 +67,4 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 
-if(QT_VERSION_MAJOR EQUAL 6)
-    qt_finalize_executable(${PROJECT_NAME})
-endif()
+qt_finalize_executable(${PROJECT_NAME})


### PR DESCRIPTION
Currently the Qt5 fallback is incorrect (`OpenGLWidgets` doesn't exist in Qt5), causing CMake to fail as long as one has Qt5 installed, however the code doesn't compile on Qt5 anyways. 

This PR hence removes all of the Qt5 fallbacks, going to a Qt6 specific CMake.

Error for reference:

```bash
CMake Error at /usr/lib/cmake/Qt5/Qt5Config.cmake:28 (find_package):
  Could not find a package configuration file provided by "Qt5OpenGLWidgets"
  with any of the following names:

    Qt5OpenGLWidgetsConfig.cmake
    qt5openglwidgets-config.cmake

  Add the installation prefix of "Qt5OpenGLWidgets" to CMAKE_PREFIX_PATH or
  set "Qt5OpenGLWidgets_DIR" to a directory containing one of the above
  files.  If "Qt5OpenGLWidgets" provides a separate development package or
  SDK, be sure it has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:17 (find_package)
  ```