### PR TITLE
Fix: Added missing #include <unordered_set> in group.cpp

### DIFF
--- a/src/item/group.cpp
+++ b/src/item/group.cpp
@@ -1,5 +1,6 @@
 #include "group.h"
 #include <stdexcept>
+#include <unordered_set>
 
 void GroupItem::draw(QPainter &painter, const QPointF &offset) {
     for (auto item : m_items) {


### PR DESCRIPTION
This Pull Request addresses a compilation error encountered when building Drawy from source on Linux (Debian 13.1).


**Issue and Fix Summary**


The file src/item/group.cpp uses std::unordered_set (line 104) but was missing the corresponding C++ header file, leading to a build failure with the error: ‘unordered_set’ is not a member of ‘std’.


This commit simply adds the required include directive to resolve the compilation error.

